### PR TITLE
Remove ref to dist/displayVcExample.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv='Content-Type' content='text/html;charset=utf-8'/>
     <script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove'></script>
     <script src="./dist/main.js" class="remove"></script>
-    <script src="./dist/displayVcExample.js"></script>
     <script type="text/javascript" class="remove">
       var respecConfig = {
         group: "vc",


### PR DESCRIPTION
Removes loading dist/displayVcExample.js from index.html. No such file. The displayVcExample function is inserted by the addVcExampleScripts function in index.js.