### PR TITLE
eslint cleanup

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,9 +8,14 @@ import * as ecdsaSd2023Cryptosuite
 import * as Ed25519Multikey from '@digitalbazaar/ed25519-multikey';
 import * as examples1Context from '@digitalbazaar/credentials-examples-context';
 import * as jose from 'jose';
+import * as mfHasher from 'multiformats/hashes/hasher';
 import * as odrlContext from '@digitalbazaar/odrl-context';
+import {base64pad, base64url} from 'multiformats/bases/base64';
 import {defaultDocumentLoader, issue} from '@digitalbazaar/vc';
 import {extendContextLoader, purposes} from 'jsonld-signatures';
+import {sha3_256, sha3_384} from '@noble/hashes/sha3';
+import {base16} from 'multiformats/bases/base16';
+import {base58btc} from 'multiformats/bases/base58';
 import {DataIntegrityProof} from '@digitalbazaar/data-integrity';
 import ed25519Context from 'ed25519-signature-2020-context';
 import {Ed25519Signature2020} from '@digitalbazaar/ed25519-signature-2020';
@@ -18,14 +23,9 @@ import {Ed25519VerificationKey2020} from
   '@digitalbazaar/ed25519-verification-key-2020';
 import {cryptosuite as eddsaRdfc2022CryptoSuite} from
   '@digitalbazaar/eddsa-rdfc-2022-cryptosuite';
-import * as mfHasher from 'multiformats/hashes/hasher';
-import {base64pad, base64url} from 'multiformats/bases/base64';
-import {base58btc} from 'multiformats/bases/base58';
-import {base16} from 'multiformats/bases/base16';
 import examples2Context from './contexts/credentials/examples/v2';
 import {sha256} from '@noble/hashes/sha256';
 import {sha384} from '@noble/hashes/sha512';
-import {sha3_256, sha3_384} from '@noble/hashes/sha3';
 
 // default types
 const TAB_TYPES = [

--- a/index.js
+++ b/index.js
@@ -318,14 +318,14 @@ async function createVcExamples() {
 
       // ensure retrieval succeeded
       if(response.status !== 200) {
-        throw new Error('Failed to retrieve '+ hashUrl);
+        throw new Error('Failed to retrieve ' + hashUrl);
       }
       const hashData = new Uint8Array(await response.arrayBuffer());
 
       // determine the hash algorithm to use and produce the output accordingly
-      if(hashFormat.includes('openssl') && hashFormat.includes('-sha256') ) {
+      if(hashFormat.includes('openssl') && hashFormat.includes('-sha256')) {
         const mfHash = await sha2256Hasher.digest(hashData);
-        encodedHash = Array.prototype.map.call(mfHash.digest, (byte) => {
+        encodedHash = Array.prototype.map.call(mfHash.digest, byte => {
           return ('0' + (byte & 0xFF).toString(16)).slice(-2);
         }).join('');
       } else if(hashFormat.includes('sri')) {

--- a/index.js
+++ b/index.js
@@ -274,22 +274,22 @@ async function createVcExamples() {
   const sha2256Hasher = mfHasher.from({
     name: 'sha2-256',
     code: 0x12,
-    encode: (input) => sha256(input)
+    encode: input => sha256(input)
   });
   const sha2384Hasher = mfHasher.from({
     name: 'sha2-384',
     code: 0x20,
-    encode: (input) => sha384(input)
+    encode: input => sha384(input)
   });
   const sha3256Hasher = mfHasher.from({
     name: 'sha3-256',
     code: 0x16,
-    encode: (input) => sha3_256(input)
+    encode: input => sha3_256(input)
   });
   const sha3384Hasher = mfHasher.from({
     name: 'sha3-384',
     code: 0x15,
-    encode: (input) => sha3_384(input)
+    encode: input => sha3_384(input)
   });
 
   const vcHashEntries = document.querySelectorAll('.vc-hash');

--- a/index.js
+++ b/index.js
@@ -293,9 +293,7 @@ async function createVcExamples() {
   });
 
   const vcHashEntries = document.querySelectorAll('.vc-hash');
-  let vcHashEntryIndex = 0;
   for(const hashEntry of vcHashEntries) {
-    vcHashEntryIndex++;
 
     // get the hash requirements
     const hashUrl = hashEntry.dataset?.hashUrl || 'INVALID_URL';


### PR DESCRIPTION
- Sort imports.
- Remove parens from single param functions.
- Remove unused vcHashEntryIndex variable.
- Remove last remaining eslint complaints.
