### PR TITLE
Remove onclick for tab loading.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
 ### Fixed
 -
 
+## 3.3.x - 2024-mm-dd
+
+### Fixed
+- Removed the onclick event for loading tab contents to allow better Respec
+  exporting.
+
 ## 3.3.0 - 2024-07-02
 
 ### Added

--- a/index.js
+++ b/index.js
@@ -545,8 +545,7 @@ async function createVcExamples() {
      */
 
     /**
-     * Add tab to tab container in DOM. Run callback function to populate
-     * content on tab click.
+     * Add tab to tab container in DOM. Run callback immediately.
      *
      * @param {string} suffix - One of the TAB_TYPES values (or `unsigned`).
      * @param {string} labelText - Human readable label name.
@@ -587,9 +586,7 @@ async function createVcExamples() {
       if(suffix === 'unsigned') {
         content.innerHTML = callback();
       } else {
-        label.addEventListener('click', async () => {
-          content.innerHTML = await callback();
-        }, {once: true});
+        callback().then(rv => content.innerHTML = rv);
       }
     }
 


### PR DESCRIPTION
ReSpec publication requires many more things for distribution
of the related dependency. Loading them statically for export
avoids that requirement and reduces the cost of rerunning the
code locally onclick (at the cost of an initial page load
during development).
