### PR TITLE
Fix conflicting tabs with sd-jwt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixed
 - Removed the onclick event for loading tab contents to allow better Respec
   exporting.
+- Create truly unique IDs for example tab content.
 
 ## 3.3.0 - 2024-07-02
 

--- a/src/sd-jwt.js
+++ b/src/sd-jwt.js
@@ -134,30 +134,33 @@ export const getSdJwtExample = async (
   const header = getHeadersHtml(message);
   const payload = getPayloadHtml(message);
   const disclosures = await getDisclosuresHtml(message);
+
+  const uniqueId = `${prefix}-${index}-${Math.random().toString(36).substring(2, 9)}`;
+
   return `
 <div class="sd-jwt-tabbed">
-    <input type="radio" id="${prefix}-tab-${index}-encoded" name="${prefix}-tabs-${index}" checked="checked" tabindex="0">
-    <input type="radio" id="${prefix}-tab-${index}-decoded" name="${prefix}-tabs-${index}" tabindex="0">
-    <input type="radio" id="${prefix}-tab-${index}-disclosures" name="${prefix}-tabs-${index}" tabindex="0">
+    <input type="radio" id="${uniqueId}-encoded" name="${uniqueId}-tabs" checked="checked" tabindex="0">
+    <input type="radio" id="${uniqueId}-decoded" name="${uniqueId}-tabs" tabindex="0">
+    <input type="radio" id="${uniqueId}-disclosures" name="${uniqueId}-tabs" tabindex="0">
     <ul class="sd-jwt-tabs">
       <li class="sd-jwt-tab">
-        <label for="${prefix}-tab-${index}-encoded">Encoded</label>
+        <label for="${uniqueId}-encoded">Encoded</label>
       </li>
       <li class="sd-jwt-tab">
-        <label for="${prefix}-tab-${index}-decoded">Decoded</label>
+        <label for="${uniqueId}-decoded">Decoded</label>
       </li>
       <li class="sd-jwt-tab">
-        <label for="${prefix}-tab-${index}-disclosures">Issuer Disclosures</label>
+        <label for="${uniqueId}-disclosures">Issuer Disclosures</label>
       </li>
     </ul>
-    <div class="sd-jwt-tab-content" id="${prefix}-content-${index}-encoded">
+    <div class="sd-jwt-tab-content" id="${uniqueId}-content-encoded">
       ${encoded}
     </div>
-    <div class="sd-jwt-tab-content" id="${prefix}-content-${index}-decoded">
+    <div class="sd-jwt-tab-content" id="${uniqueId}-content-decoded">
       ${header}
       ${payload}
     </div>
-    <div class="sd-jwt-tab-content" id="${prefix}-content-${index}-disclosures">
+    <div class="sd-jwt-tab-content" id="${uniqueId}-content-disclosures">
       ${disclosures}
     </div>
 </div>


### PR DESCRIPTION
I noticed a small bug. when there were multiple sub-tabs open with sd-jwt examples one of the examples disappeared. this was due to overlapping div IDs. this fix generates unique IDs to prevent this conflict.

I've tested the fix locally and it works.