### PR TITLE
Releasing v3.3.5.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@
 - Changed headers in examples to use `<strong>` instead of `<h1>` for HTML
   validation and accessibility.
 
+## 3.3.4 - 2024-08-17
+
+### Fixed
+- Await rendering for headless ReSpec/Echidna useage.
+
 ## 3.3.3 - 2024-08-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Fixed
 -
 
-## 3.x.x - 2024-mm-dd
+## 3.3.5 - 2024-09-18
 
 ### Fixed
 - Moved `sd-jwt` tab to end of tab list to fix `cose` rendering.


### PR DESCRIPTION
- Add CHANGELOG entry for phantom v3.3.4.
- Release v3.3.5.

Plan is to merge this into `main` and then follow the distribution procedure (i.e. make a tag and branch named `3.3.5`) from that commit on `main` with _no other changes on the branch_.