### PR TITLE
Correct signing algorithm identifier to -9 (ESP256)

### DIFF
--- a/src/cose.js
+++ b/src/cose.js
@@ -63,7 +63,7 @@ const getBinaryMessage = async (privateKey, messageType, messageJson) => {
   const byteSigner = {
     sign: async payload => {
       return signer.sign({
-        protectedHeader: new Map([[1, -35]]),
+        protectedHeader: new Map([[1, -9]]),
         unprotectedHeader: new Map(),
         payload,
       });


### PR DESCRIPTION
Fixes https://github.com/w3c/vc-jose-cose/issues/339

The actual signing algorithm used is ES256, per https://github.com/w3c/respec-vc/blob/main/index.js#L566 , but COSE algorithm identifier -35 (ES384) was hardcoded, which didn't match.

This PR changes the algorithm identifier to -9 (ESP256) - the fully-specified COSE algorithm identifier for ES256.

After this change, the VC-JOSE-COSE COSE examples should have signatures matching their algorithms.

Cc: @msporny @brentzundel @OR13 @decentralgabe 